### PR TITLE
[feature/#03] 질문 등록 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,22 +13,24 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "@babel/core": "^7.20.12",
     "@emotion/react": "^11.10.6",
-    "@emotion/styled": "^11.10.6"
+    "@emotion/styled": "^11.10.6",
+    "jotai": "^2.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "^7.20.13",
     "@emotion/babel-plugin-jsx-pragmatic": "^0.2.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
-    "@vitejs/plugin-react": "^3.1.0",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
-    "typescript": "^4.9.3",
-    "vite": "^4.1.0",
+    "@vitejs/plugin-react": "^3.1.0",
+    "babel-plugin-macros": "^3.1.0",
+    "commitizen": "4.2.4",
+    "cz-customizable": "^7.0.0",
     "eslint": "^8.33.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",
@@ -38,14 +40,13 @@
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "husky": "^8.0.0",
     "prettier": "^2.8.3",
-    "vite-tsconfig-paths": "^4.0.5",
-    "commitizen": "4.2.4",
-    "cz-customizable": "^7.0.0",
-    "babel-plugin-macros": "^3.1.0",
     "tailwindcss": "^3.2.7",
     "twin.macro": "^3.1.0",
-    "husky": "^8.0.0"
+    "typescript": "^4.9.3",
+    "vite": "^4.1.0",
+    "vite-tsconfig-paths": "^4.0.5"
   },
   "config": {
     "commitizen": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ specifiers:
   eslint-plugin-react: ^7.32.2
   eslint-plugin-react-hooks: ^4.6.0
   husky: ^8.0.0
+  jotai: ^2.0.2
   prettier: ^2.8.3
   react: ^18.2.0
   react-dom: ^18.2.0
@@ -37,6 +38,7 @@ dependencies:
   '@babel/core': 7.21.0
   '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
   '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
+  jotai: 2.0.2_react@18.2.0
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
 
@@ -2690,6 +2692,18 @@ packages:
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
+
+  /jotai/2.0.2_react@18.2.0:
+    resolution: {integrity: sha512-0yOked08Swa84LUbBjtj7ZLZrE05n3u50rHeZ+bsT86thUjcy0kFgQz9GmEWhYbQDFoT1G8Ww6edSj/MBJHO4A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /js-sdsl/4.3.0:
     resolution: {integrity: sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,11 @@
 import tw from 'twin.macro';
 
-import { Button } from '@/components';
+import { QuestionPage } from '@/pages';
 
 const App = () => (
   <Container>
     <MobileContainer>
-      <Button>질문하기</Button>
+      <QuestionPage />
     </MobileContainer>
   </Container>
 );

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -6,16 +6,24 @@ type AlertProps = {
   titleText: string;
   infoText: string;
   cancelable?: boolean;
+  onConfirm?: () => void;
+  onCancel?: () => void;
 };
 
-const Alert = ({ titleText, infoText, cancelable = false }: AlertProps) => (
+const Alert = ({
+  titleText,
+  infoText,
+  cancelable = false,
+  onConfirm = () => {},
+  onCancel = () => {},
+}: AlertProps) => (
   <WrappingContainer>
     <Container>
       <Title>{titleText}</Title>
       <Info>{infoText}</Info>
       <ButtonContainer>
-        {cancelable && <CancelButton>취소</CancelButton>}
-        <ConfirmButton>확인</ConfirmButton>
+        {cancelable && <CancelButton onClick={onCancel}>취소</CancelButton>}
+        <ConfirmButton onClick={onConfirm}>확인</ConfirmButton>
       </ButtonContainer>
     </Container>
   </WrappingContainer>

--- a/src/domains/components/QuestionForm.tsx
+++ b/src/domains/components/QuestionForm.tsx
@@ -1,22 +1,40 @@
-import React, { useState } from 'react';
+import React from 'react';
 
+import { useAtomValue, useSetAtom } from 'jotai';
 import tw from 'twin.macro';
 
-import { Alert, Button, Input } from '@/components';
+import { Button, Input } from '@/components';
 import { useInput } from '@/hooks';
 
+import QuestionRegisterPopup from './QuestionRegisterPopup';
+import TermOfUsePopup from './TermOfUsePopup';
+import {
+  dequeueModalPopupQueueAtom,
+  pushModalPopupQueueAtom,
+} from '../store/actions';
+import { currentModalPopupAtom } from '../store/atoms';
+import { 이용약관동의여부확인 } from '../utils';
+
 const QuestionForm = () => {
-  const [open, setOpen] = useState(false);
+  const modalPopup = useAtomValue(currentModalPopupAtom);
+  const createModalPopup = useSetAtom(pushModalPopupQueueAtom);
+  const closeModalPopup = useSetAtom(dequeueModalPopupQueueAtom);
   const { value: question, onChange, reset } = useInput();
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    reset();
-    setOpen(true);
-  };
-
-  const handleConfirm = () => {
-    setOpen(false);
+    const 약관동의여부 = 이용약관동의여부확인();
+    if (!약관동의여부) {
+      createModalPopup(<TermOfUsePopup />);
+    }
+    createModalPopup(
+      <QuestionRegisterPopup
+        onConfirm={() => {
+          closeModalPopup();
+          reset();
+        }}
+      />,
+    );
   };
 
   return (
@@ -30,13 +48,7 @@ const QuestionForm = () => {
         />
         <Button type='submit'>질문하기</Button>
       </Form>
-      {open && (
-        <Alert
-          titleText='질문이 등록되었어요'
-          infoText='답변이 오면 알려드릴게요.'
-          onConfirm={handleConfirm}
-        />
-      )}
+      {modalPopup}
     </>
   );
 };

--- a/src/domains/components/QuestionForm.tsx
+++ b/src/domains/components/QuestionForm.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+import tw from 'twin.macro';
+
+import { Alert, Button, Input } from '@/components';
+import { useInput } from '@/hooks';
+
+const QuestionForm = () => {
+  const [open, setOpen] = useState(false);
+  const { value: question, onChange, reset } = useInput();
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    reset();
+    setOpen(true);
+  };
+
+  const handleConfirm = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Form onSubmit={handleSubmit}>
+        <Input
+          placeholder='어떤 내용이 궁금한가요?'
+          tw='mb-7'
+          onChange={onChange}
+          value={question}
+        />
+        <Button type='submit'>질문하기</Button>
+      </Form>
+      {open && (
+        <Alert
+          titleText='질문이 등록되었어요'
+          infoText='답변이 오면 알려드릴게요.'
+          onConfirm={handleConfirm}
+        />
+      )}
+    </>
+  );
+};
+
+const Form = tw.form`flex h-full flex-col justify-center items-center`;
+
+export default QuestionForm;

--- a/src/domains/components/QuestionRegisterPopup.tsx
+++ b/src/domains/components/QuestionRegisterPopup.tsx
@@ -1,0 +1,15 @@
+import { Alert } from '@/components';
+
+type IProps = {
+  onConfirm: () => void;
+};
+
+const QuestionRegisterPopup = ({ onConfirm }: IProps) => (
+  <Alert
+    titleText='질문이 등록되었어요'
+    infoText='답변이 오면 알려드릴게요.'
+    onConfirm={onConfirm}
+  />
+);
+
+export default QuestionRegisterPopup;

--- a/src/domains/components/TermOfUsePopup.tsx
+++ b/src/domains/components/TermOfUsePopup.tsx
@@ -1,0 +1,34 @@
+import { useSetAtom } from 'jotai';
+import { useResetAtom } from 'jotai/utils';
+
+import { Alert } from '@/components';
+
+import { dequeueModalPopupQueueAtom } from '../store/actions';
+import { modalPopupQueueAtom } from '../store/atoms';
+import { 이용약관동의하기 } from '../utils';
+
+const TermOfUsePopup = () => {
+  const closeModalPopup = useSetAtom(dequeueModalPopupQueueAtom);
+  const clearModalPopupQueue = useResetAtom(modalPopupQueueAtom);
+
+  const handleSubmit = () => {
+    이용약관동의하기();
+    closeModalPopup();
+  };
+
+  const handleCancel = () => {
+    clearModalPopupQueue();
+  };
+
+  return (
+    <Alert
+      titleText='약관에 동의하시겠습니까?'
+      infoText='약관 동의가 필요합니다.'
+      cancelable
+      onConfirm={handleSubmit}
+      onCancel={handleCancel}
+    />
+  );
+};
+
+export default TermOfUsePopup;

--- a/src/domains/components/index.ts
+++ b/src/domains/components/index.ts
@@ -1,0 +1,1 @@
+export { default as QuestionForm } from './QuestionForm';

--- a/src/domains/store/actions/index.ts
+++ b/src/domains/store/actions/index.ts
@@ -1,0 +1,4 @@
+export {
+  pushModalPopupQueueAtom,
+  dequeueModalPopupQueueAtom,
+} from './modalPopupQueue';

--- a/src/domains/store/actions/modalPopupQueue.ts
+++ b/src/domains/store/actions/modalPopupQueue.ts
@@ -1,0 +1,14 @@
+import { atom } from 'jotai';
+
+import { modalPopupQueueAtom } from '../atoms/modalPopupQueue';
+
+export const pushModalPopupQueueAtom = atom(
+  null,
+  (get, set, popup: JSX.Element) => {
+    set(modalPopupQueueAtom, (queue) => [...queue, popup]);
+  },
+);
+
+export const dequeueModalPopupQueueAtom = atom(null, (get, set) => {
+  set(modalPopupQueueAtom, (queue) => queue.slice(1));
+});

--- a/src/domains/store/atoms/index.ts
+++ b/src/domains/store/atoms/index.ts
@@ -1,0 +1,1 @@
+export { modalPopupQueueAtom, currentModalPopupAtom } from './modalPopupQueue';

--- a/src/domains/store/atoms/modalPopupQueue.ts
+++ b/src/domains/store/atoms/modalPopupQueue.ts
@@ -1,0 +1,8 @@
+import { atom } from 'jotai';
+import { atomWithReset } from 'jotai/utils';
+
+export const modalPopupQueueAtom = atomWithReset<JSX.Element[]>([]);
+
+export const currentModalPopupAtom = atom(
+  (get) => get(modalPopupQueueAtom)[0] ?? null,
+);

--- a/src/domains/utils/agreement.ts
+++ b/src/domains/utils/agreement.ts
@@ -1,0 +1,10 @@
+const 이용약관동의여부확인 = () => {
+  const agreement = localStorage.getItem('agreement');
+  return agreement === 'true';
+};
+
+const 이용약관동의하기 = () => {
+  localStorage.setItem('agreement', 'true');
+};
+
+export { 이용약관동의여부확인, 이용약관동의하기 };

--- a/src/domains/utils/index.ts
+++ b/src/domains/utils/index.ts
@@ -1,0 +1,1 @@
+export { 이용약관동의여부확인, 이용약관동의하기 } from './agreement';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useInput } from './useInput';

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,0 +1,15 @@
+import { useState, useCallback } from 'react';
+
+const useInput = (initalValue = '') => {
+  const [value, setValue] = useState(initalValue);
+
+  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  }, []);
+
+  const reset = useCallback(() => setValue(initalValue), [initalValue]);
+
+  return { value, onChange, reset };
+};
+
+export default useInput;

--- a/src/pages/QuestionPage.tsx
+++ b/src/pages/QuestionPage.tsx
@@ -1,0 +1,5 @@
+import { QuestionForm } from '@/domains/components';
+
+const QuestionPage = () => <QuestionForm />;
+
+export default QuestionPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,1 @@
+export { default as QuestionPage } from './QuestionPage';


### PR DESCRIPTION
## ⛳️ 작업한 브랜치
- feature/#03

## 📁 작업한 내용
- [x]  컴포넌트 조합(도메인 구성)
- [x]  이벤트 바인딩
- [x] 약관 동의 분기 처리

## 📌 PR Point
- jotai 전역 상태 라이브러리를 적용했습니다
   - 적용 이유
        - 질문 제출하기 버튼을 누르면 약관 동의 팝업이 나타난 후, 확인을 누르면 질문 등록 팝업이 나타나는 형태인데, 이 상태를 local로 관리하기에는 하나의 컴포넌트에 상태를 관리하는 코드가 너무 많아질 것 같았습니다
        - onSubmit, onCancel 이벤트 핸들러를 팝업 컴포넌트 안에서 선언하는 방식으로 추상화를 시키고 싶었습니다
- Modal&Popup을 Queue 자료구조로 관리하여 한 화면에 여러 개의 Modal, Popup이 등장할 수 있도록 구현하였습니다
- 약관동의여부 상태는 localStorage에 저장하여 관리합니다
- 추상화 수준을 똑같이 하고 싶었지만, QuestionRegisterPopup 컴포넌트에서 확인 버튼이 눌리면(onSubmit) input이 reset되는 함수를 넘겨주는 것 때문에 TermOfUsePopup 컴포넌트와는 다르게 onSubmit을 props로 넘겨주었습니다. props를 넘겨주지 않으려면 input도 전역 상태로 관리해야하는데, 너무 투머치하게 전역 상태를 사용하는 것 같아 이와 같이 구현하였습니다
![code](https://user-images.githubusercontent.com/72335632/221418400-7eeb2271-f7b6-4bcb-b60b-f5c6e57d09c4.png)


## 📢 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷


## 👣 관련 이슈
- closed: #03